### PR TITLE
Fix scoop installation

### DIFF
--- a/dotenv-linter.json
+++ b/dotenv-linter.json
@@ -6,6 +6,7 @@
   "architecture": {
     "64bit": {
       "url": "https://github.com/dotenv-linter/dotenv-linter/releases/download/v2.1.0/dotenv-linter-win-x64.zip",
+      "hash": "244e85656a0139c7bb9b42573fe92b99562a184e78ed99283ff3e20e18f7814b",
       "extract_dir": "dotenv-linter-2.1.0-win-x64"
     }
   },

--- a/dotenv-linter.json
+++ b/dotenv-linter.json
@@ -6,8 +6,7 @@
   "architecture": {
     "64bit": {
       "url": "https://github.com/dotenv-linter/dotenv-linter/releases/download/v2.1.0/dotenv-linter-win-x64.zip",
-      "hash": "244e85656a0139c7bb9b42573fe92b99562a184e78ed99283ff3e20e18f7814b",
-      "extract_dir": "dotenv-linter-2.1.0-win-x64"
+      "hash": "244e85656a0139c7bb9b42573fe92b99562a184e78ed99283ff3e20e18f7814b"
     }
   },
   "bin": "dotenv-linter.exe",
@@ -15,8 +14,7 @@
   "autoupdate": {
     "architecture": {
       "64bit": {
-        "url": "https://github.com/dotenv-linter/dotenv-linter/releases/download/v$version/dotenv-linter-win-x64.zip",
-        "extract_dir": "dotenv-linter-$version-win-x64"
+        "url": "https://github.com/dotenv-linter/dotenv-linter/releases/download/v$version/dotenv-linter-win-x64.zip"
       }
     }
   }


### PR DESCRIPTION
After release v2.1.0, I decided to check the installation using Scoop.
And I came across two things and _**fixed them in a local bucket**_:
1)  ### Warning: No hash in manifest
<details>
  <summary>Before fix</summary>

`WARN  Warning: No hash in manifest. SHA256 for 'dotenv-linter-win-x64.zip' is:                                              244e85656a0139c7bb9b42573fe92b99562a184e78ed99283ff3e20e18f7814b`
</details>

<details>
  <summary>After fix</summary>

```
Loading dotenv-linter-win-x64.zip from cache
Checking hash of dotenv-linter-win-x64.zip ... ok.
```
</details>


2) ### Extracting to specified dirictory failed

This is because Scoop automatically determines the folder for zip archives and our field value coincided with zip name: [documentation](https://github.com/lukesampson/scoop/wiki/App-Manifests) (see `extract_dir`).

<details>
  <summary>Before fix</summary>

```
Extracting dotenv-linter-win-x64.zip ... Could not find 'dotenv-linter-2.1.0-win-x64'! (error 16)                       
C:\Users\DDtKey\scoop\apps\scoop\current\lib\core.ps1:510 char:9 
+         throw "Could not find '$(fname $from)'! (error $($proc.ExitCo ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+ CategoryInfo          : OperationStopped: (Could not find ...64'! (error 16):String) [], RuntimeException
+ FullyQualifiedErrorId : Could not find 'dotenv-linter-2.1.0-win-x64'! (error 16
```
</details>

<details>
  <summary>After fix</summary>

```
PS C:\Users\DDtKey> scoop install dotenv-linter/dotenv-linter                                                          
Installing 'dotenv-linter' (2.1.0) [64bit]                                                                              
Loading dotenv-linter-win-x64.zip from cache                                                                            
Checking hash of dotenv-linter-win-x64.zip ... ok.                                                                      
Extracting dotenv-linter-win-x64.zip ... done.                                                                          
Linking ~\scoop\apps\dotenv-linter\current => ~\scoop\apps\dotenv-linter\2.1.0                                          
Creating shim for 'dotenv-linter'.                                                                                      
'dotenv-linter' (2.1.0) was installed successfully!     
                                                                
PS C:\Users\DDtKey> dotenv-linter -v                                                                                    
dotenv-linter 2.1.0
```
</details>

Applied fix will identify the folder by zip name, as we expect.
